### PR TITLE
Add topic type to publish the position of object 

### DIFF
--- a/aerial_robot_perception/include/aerial_robot_perception/ground_object_detection_with_size_filter.h
+++ b/aerial_robot_perception/include/aerial_robot_perception/ground_object_detection_with_size_filter.h
@@ -64,6 +64,7 @@ namespace aerial_robot_perception
 
   protected:
     /* ros publisher */
+    ros::Publisher target_pos_pub_;
     image_transport::Publisher image_pub_; //for debug
 
     /* ros subscriber */

--- a/aerial_robot_perception/test/test-single_color_ground_object_detection.test
+++ b/aerial_robot_perception/test/test-single_color_ground_object_detection.test
@@ -48,7 +48,7 @@
         pkg="rostest" type="publishtest">
     <rosparam>
       topics:
-      - name: /ground_object_detection_with_size_filter/debug_image
+      - name: /target_object/pos
       timeout: 10
       negative: False
     </rosparam>


### PR DESCRIPTION
I think the topic type output will be helpful for some relatively realtime system, since  `lookup` in TF api sometimes will give a certain delay. 