### PR TITLE
Add an independent subscriber for camera info message

### DIFF
--- a/aerial_robot_perception/include/aerial_robot_perception/ground_object_detection_with_size_filter.h
+++ b/aerial_robot_perception/include/aerial_robot_perception/ground_object_detection_with_size_filter.h
@@ -60,7 +60,7 @@ namespace aerial_robot_perception
   class GroundObjectDetectionWithSizeFilter: public jsk_topic_tools::DiagnosticNodelet
   {
   public:
-    GroundObjectDetectionWithSizeFilter(): DiagnosticNodelet("GroundObjectDetectionWithSizeFilter") {}
+    GroundObjectDetectionWithSizeFilter(): DiagnosticNodelet("GroundObjectDetectionWithSizeFilter"), real_size_scale_(0) {}
 
   protected:
     /* ros publisher */
@@ -69,6 +69,7 @@ namespace aerial_robot_perception
 
     /* ros subscriber */
     image_transport::Subscriber image_sub_;
+    ros::Subscriber cam_info_sub_;
 
     /* image transport */
     boost::shared_ptr<image_transport::ImageTransport> it_;
@@ -88,6 +89,7 @@ namespace aerial_robot_perception
     tf2::Matrix3x3 camera_K_inv_;
 
     void imageCallback(const sensor_msgs::ImageConstPtr& msg);
+    void cameraInfoCallback(const sensor_msgs::CameraInfoConstPtr& msg);
 
     virtual void onInit();
     virtual void subscribe();


### PR DESCRIPTION
For most of the well-implemented sensor interfaces, the image is not always published (e.g. [zed](https://github.com/stereolabs/zed-ros-wrapper)), and only there is at least one subscriber for this topic, the sensor interface would start to publish the image and **related** camera info. 

So,  `ros::topic::waitForMessage<sensor_msgs::CameraInfo>` in [onInit()](https://github.com/tongtybj/aerial_robot_recognition/blob/master/aerial_robot_perception/src/ground_object_detection_with_size_filter.cpp#L60 ) function would never receive the CameraInfo message, since there is no any trigger for sensor interface to publish message at that time point. 

A temporary solution is to create an external trigger for the sensor interface, such as  here:
https://github.com/tongtybj/aerial_robot_demo/blob/master/mbzirc2020_task3/mbzirc2020_task3_common/launch/hydrus_bringup.launch#L71-L77.
However, this is not smart.

This PR fixes this problem, by adding (reverting) the subscriber for CameraInfo.