### PR TITLE
Refactor the detection mode

### DIFF
--- a/aerial_robot_perception/CMakeLists.txt
+++ b/aerial_robot_perception/CMakeLists.txt
@@ -44,7 +44,7 @@ macro(arp_add_nodelet _nodelet_cpp _nodelet_class _single_nodelet_exec_name)
     ${PROJECT_NAME}_nodelet_sources ${PROJECT_NAME}_nodelet_executables)
 endmacro()
 
-arp_add_nodelet(src/ground_object_detection_with_size_filter.cpp "aerial_robot_perception/groundObjectDetectionWithSizeFilter" "ground_object_detection_with_size_filter")
+arp_add_nodelet(src/ground_object_detection.cpp "aerial_robot_perception/groundObjectDetection" "ground_object_detection")
 
 add_library(${PROJECT_NAME} SHARED ${aerial_robot_perception_nodelet_sources})
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OpenCV_LIBRARIES})

--- a/aerial_robot_perception/include/aerial_robot_perception/ground_object_detection.h
+++ b/aerial_robot_perception/include/aerial_robot_perception/ground_object_detection.h
@@ -56,11 +56,10 @@
 
 namespace aerial_robot_perception
 {
-
-  class GroundObjectDetectionWithSizeFilter: public jsk_topic_tools::DiagnosticNodelet
+  class GroundObjectDetection: public jsk_topic_tools::DiagnosticNodelet
   {
   public:
-    GroundObjectDetectionWithSizeFilter(): DiagnosticNodelet("GroundObjectDetectionWithSizeFilter"), real_size_scale_(0) {}
+    GroundObjectDetection(): DiagnosticNodelet("GroundObjectDetection"), real_size_scale_(0) {}
 
   protected:
     /* ros publisher */
@@ -97,3 +96,4 @@ namespace aerial_robot_perception
   };
 
 } //namespace aerial_robot_perception
+

--- a/aerial_robot_perception/launch/single_color_ground_object_detection.launch
+++ b/aerial_robot_perception/launch/single_color_ground_object_detection.launch
@@ -3,9 +3,10 @@
   <arg name="image_topic" default="image" />
   <arg name="camera_info_topic" default="camera_info" />
   <arg name="debug_view" default="false"/>
-  <arg name="object_height" default="0.2"/>
-  <arg name="contour_area_size" default="0.05"/>
-  <arg name="contour_area_margin" default="0.01"/>
+  <arg name="size_filter" default="false"/>
+  <arg name="object_height" default="0.0"/>
+  <arg name="contour_area_size" default="0.0"/>
+  <arg name="contour_area_margin" default="0.0"/>
   <arg name="frame_id" default="target_object"/>
   <arg name="h_limit_max" default="33" doc="The maximum allowed field value Hue" />
   <arg name="h_limit_min" default="10" doc="The minimum allowed field value Hue" />
@@ -30,7 +31,7 @@
   </node>
 
   <node pkg="nodelet" type="nodelet" name="ground_object_detection_with_size_filter"
-        args="load aerial_robot_perception/GroundObjectDetectionWithSizeFilter object_detection_nodelet" output="screen">
+        args="load aerial_robot_perception/GroundObjectDetection object_detection_nodelet" output="screen">
     <remap from="image" to="/hsv_color_filter/image" />
     <remap from="camera_info" to="$(arg camera_info_topic)"/>
     <param name="object_height" value="$(arg object_height)"/>

--- a/aerial_robot_perception/plugins/nodelet/aerial_robot_perception_nodelet.xml
+++ b/aerial_robot_perception/plugins/nodelet/aerial_robot_perception_nodelet.xml
@@ -1,6 +1,6 @@
 <library path="lib/libaerial_robot_perception">
-  <class name="aerial_robot_perception/GroundObjectDetectionWithSizeFilter"
-         type="aerial_robot_perception::GroundObjectDetectionWithSizeFilter"
+  <class name="aerial_robot_perception/GroundObjectDetection"
+         type="aerial_robot_perception::GroundObjectDetection"
          base_class_type="nodelet::Nodelet">
   </class>
 </library>

--- a/aerial_robot_perception/test/CMakeLists.txt
+++ b/aerial_robot_perception/test/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_rostest(test-single_color_ground_object_detection.test ARGS gui:=false)
+add_rostest(test-single_color_ground_object_detection.test ARGS contour_area_size:=0 gui:=false) # max size mode
+add_rostest(test-single_color_ground_object_detection.test ARGS gui:=false) # size filtering mode
 
 if(roslaunch_VERSION VERSION_LESS "1.11.1")
   message(WARNING "roslaunch_add_file check fails with unsupported doc attributes ${roslaunch_VERSION}")

--- a/aerial_robot_perception/test/test-single_color_ground_object_detection.test
+++ b/aerial_robot_perception/test/test-single_color_ground_object_detection.test
@@ -1,6 +1,7 @@
 <launch>
   <arg name="input_image" default="/downward_camera/image"/>
   <arg name="gui" default="True"/>
+  <arg name="contour_area_size" default="0.05"/>
 
   <include file="$(find aerial_robot_perception)/launch/single_color_ground_object_detection.launch">
     <arg name="image_topic" value="$(arg input_image)"/>
@@ -8,7 +9,7 @@
     <arg name="debug_view" value="true"/>
     <arg name="output_screen" value="false"/>
     <arg name="object_height" default="0.2"/>
-    <arg name="contour_area_size" default="0.05"/>
+    <arg name="contour_area_size" default="$(arg contour_area_size)"/>
     <arg name="contour_area_margin" default="0.01"/>
   </include>
 


### PR DESCRIPTION
1. size filtering mode: 
    If the arg `contour_area_size_` is non-zero, we use this value as the filter to find the closest object in terms of size, from candidate contours.
2. maximum size mode:
   If we do not know the extract size of the object (e.g. deforming object like fire). Then the biggest contoure will be selected.

Please refer to following lines for the mode selection.
https://github.com/tongtybj/aerial_robot_recognition/blob/8ca7302fc7b10545411f6a15f3fe4e4ae74f3bf1/aerial_robot_perception/test/CMakeLists.txt#L1-L2