### PR TITLE
add rectangle detector using depth

### DIFF
--- a/aerial_robot_perception/CMakeLists.txt
+++ b/aerial_robot_perception/CMakeLists.txt
@@ -49,6 +49,8 @@ endmacro()
 arp_add_nodelet(src/ground_object_detection.cpp "aerial_robot_perception/groundObjectDetection" "ground_object_detection")
 arp_add_nodelet(src/cluttered_brick_detection.cpp "aerial_robot_perception/ClutteredBrickDetection" "cluttered_brick_detection")
 arp_add_nodelet(src/laser_line_extraction_ros.cpp "aerial_robot_perception/LaserLineExtraction" "laser_line_extraction")
+arp_add_nodelet(src/rectangle_detection_depth.cpp "aerial_robot_perception/RectangleDetectionDepth" "rectangle_detection_depth")	
+
 
 add_library(${PROJECT_NAME} SHARED ${aerial_robot_perception_nodelet_sources} src/line_extraction.cpp)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OpenCV_LIBRARIES})

--- a/aerial_robot_perception/include/aerial_robot_perception/rectangle_detection_depth.h
+++ b/aerial_robot_perception/include/aerial_robot_perception/rectangle_detection_depth.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <random>
+#include <unistd.h>
+#include <ros/ros.h>
+#include <ros/topic.h>
+#include <sensor_msgs/Image.h>
+#include <sensor_msgs/CameraInfo.h>
+#include <sensor_msgs/image_encodings.h>
+#include <std_msgs/Float64.h>
+#include <std_msgs/Int32.h>
+#include "std_msgs/MultiArrayLayout.h"
+#include "std_msgs/MultiArrayDimension.h"
+#include "std_msgs/Int32MultiArray.h"
+#include <geometry_msgs/TransformStamped.h>
+#include <geometry_msgs/Point.h>
+#include <opencv2/opencv.hpp>
+#include <cv_bridge/cv_bridge.h>
+#include <image_transport/image_transport.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/sensor_model/camera_depth_sensor.h>
+
+namespace aerial_robot_perception
+{
+  class RectangleDetectionDepth: public jsk_topic_tools::DiagnosticNodelet
+  {
+  public:
+    RectangleDetectionDepth(): DiagnosticNodelet("RectangleDetectionDepth"){}
+
+  protected:
+    /* ros publisher */
+    ros::Publisher target_pub_;  
+    image_transport::Publisher image_pub_;
+
+    /* ros subscriber */
+    image_transport::Subscriber image_sub_;
+    image_transport::Subscriber depth_image_sub_;
+    ros::Subscriber cam_info_sub_;
+
+    /* image transport */
+    boost::shared_ptr<image_transport::ImageTransport> it_;
+
+    /* tf */
+    tf2_ros::TransformBroadcaster tf_br_;
+    tf2_ros::Buffer tf_buff_;
+    boost::shared_ptr<tf2_ros::TransformListener> tf_ls_;
+
+    /* ros param */
+    bool debug_view_;
+    std::string frame_id_;
+    
+    double real_size_scale_;
+    tf2::Matrix3x3 camera_K_inv_;
+    tf2::Matrix3x3 camera_K;
+
+    int lowest_margin_;
+    
+    double object_distance, object_height_;
+    geometry_msgs::Vector3Stamped obj_pos_msg;
+    tf2::Vector3 cam_target_xyz;
+    cv::Mat rgb_img, depth_img;
+
+    void imageCallback(const sensor_msgs::ImageConstPtr& msg);
+    void depthImageCallback(const sensor_msgs::ImageConstPtr& msg);
+    void cameraInfoCallback(const sensor_msgs::CameraInfoConstPtr& msg);
+    
+    virtual void onInit();
+    virtual void subscribe();
+    virtual void unsubscribe();
+  };
+}

--- a/aerial_robot_perception/launch/rectangle_detection_depth.launch
+++ b/aerial_robot_perception/launch/rectangle_detection_depth.launch
@@ -1,0 +1,25 @@
+<launch>
+  <arg name="output_screen" default="true"/>
+  <arg name="image_topic" default="image" />
+  <arg name="image_depth_topic" default="image_depth" />
+  <arg name="camera_info_topic" default="cam_info" />
+  <arg name="debug_view" default="true"/>
+  <arg name="marker_debug" default="true"/>
+  <arg name="frame_id" default="target_object"/>
+  <arg name="camera" default="rs_d435"/>
+  <arg name="gui" default="true"/>
+
+  <node pkg="nodelet" type="nodelet" name="rectangle_detection_depth_nodelet" args="manager" output="screen" if="$(arg output_screen)"/>
+
+  <node pkg="nodelet" type="nodelet" name="rectangle_detection_depth"
+        args="load aerial_robot_perception/RectangleDetectionDepth rectangle_detection_depth_nodelet" output="screen">
+
+    <remap from="rgb_img" to="/rs_d435/color/image_rect_color" />
+    <remap from="depth_image" to="/rs_d435/aligned_depth_to_color/image_raw" />
+    <remap from="cam_info" to="/rs_d435/aligned_depth_to_color/camera_info" />
+    
+    <param name="debug_view" value="$(arg debug_view)"/>
+    <param name="frame_id" value="$(arg frame_id)"/>
+  </node>
+
+</launch>

--- a/aerial_robot_perception/plugins/nodelet/aerial_robot_perception_nodelet.xml
+++ b/aerial_robot_perception/plugins/nodelet/aerial_robot_perception_nodelet.xml
@@ -9,10 +9,15 @@
          type="aerial_robot_perception::ClutteredBrickDetection"
          base_class_type="nodelet::Nodelet">
   </class>
-
+  
   <class name="aerial_robot_perception/LaserLineExtraction"
          type="aerial_robot_perception::LaserLineExtraction"
          base_class_type="nodelet::Nodelet">
   </class>
-
+  
+  <class name="aerial_robot_perception/RectangleDetectionDepth"
+         type="aerial_robot_perception::RectangleDetectionDepth"
+         base_class_type="nodelet::Nodelet">
+  </class>
+  
 </library>

--- a/aerial_robot_perception/src/ground_object_detection.cpp
+++ b/aerial_robot_perception/src/ground_object_detection.cpp
@@ -31,7 +31,7 @@
  *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
- *********************************************************************/
+n *********************************************************************/
 
 #include <aerial_robot_perception/ground_object_detection.h>
 

--- a/aerial_robot_perception/src/rectangle_detection_depth.cpp
+++ b/aerial_robot_perception/src/rectangle_detection_depth.cpp
@@ -1,0 +1,179 @@
+#include <aerial_robot_perception/rectangle_detection_depth.h>
+
+namespace aerial_robot_perception
+{
+
+  void RectangleDetectionDepth::onInit()
+  {
+    DiagnosticNodelet::onInit();
+
+    pnh_->param("debug_view", debug_view_, true);
+    pnh_->param("frame_id", frame_id_, std::string("target"));
+    pnh_->param("lowest_margin", lowest_margin_, 10);
+    pnh_->param("object_height", object_height_, 0.20);
+    always_subscribe_ = true;
+
+    if (debug_view_) image_pub_ = advertiseImage(*pnh_, "debug_image", 1);
+    target_pub_ = advertise<geometry_msgs::TransformStamped>(*nh_, frame_id_, 1);
+    
+    it_ = boost::make_shared<image_transport::ImageTransport>(*nh_);
+    tf_ls_ = boost::make_shared<tf2_ros::TransformListener>(tf_buff_);
+
+    ros::Duration(1.0).sleep();
+
+    onInitPostProcess();
+  }
+
+  void RectangleDetectionDepth::subscribe()
+  {
+    if(debug_view_) image_sub_ = it_->subscribe("rgb_img", 1, &RectangleDetectionDepth::imageCallback, this);
+    depth_image_sub_ = it_->subscribe("depth_image", 1, &RectangleDetectionDepth::depthImageCallback, this);
+    cam_info_sub_ = nh_->subscribe("cam_info", 1, &RectangleDetectionDepth::cameraInfoCallback, this);
+  }
+
+  void RectangleDetectionDepth::unsubscribe()
+  {
+    image_sub_.shutdown();
+  }
+
+
+  void RectangleDetectionDepth::cameraInfoCallback(const sensor_msgs::CameraInfoConstPtr& msg)
+  {
+    /* the following process is executed once */
+    NODELET_DEBUG_STREAM("receive camera info");
+    tf2::Matrix3x3 camera_K_normal(msg->K[0], msg->K[1], msg->K[2],
+                            msg->K[3], msg->K[4], msg->K[5],
+                            msg->K[6], msg->K[7], msg->K[8]);
+
+    camera_K_inv_ = camera_K_normal.inverse();
+    camera_K = camera_K_normal;
+    real_size_scale_ = msg->K[0] * msg->K[4];
+    cam_info_sub_.shutdown();
+  }
+
+
+  void RectangleDetectionDepth::imageCallback(const sensor_msgs::ImageConstPtr& msg)
+  {
+    cv_bridge::CvImagePtr cv_ptr;
+    cv_ptr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::BGR8);
+    rgb_img = cv_ptr->image;
+  }
+
+  
+  void RectangleDetectionDepth::depthImageCallback(const sensor_msgs::ImageConstPtr& msg)
+  {
+    int image_width = 1280;
+    int image_height = 720;
+
+    tf2::Transform cam_tf;
+    try{
+      geometry_msgs::TransformStamped cam_pose_msg = tf_buff_.lookupTransform("world", "rs_d435_color_optical_frame", ros::Time(0));
+      tf2::convert(cam_pose_msg.transform, cam_tf);
+    }
+    catch (tf2::TransformException &ex) {
+      ROS_WARN("%s", ex.what());
+      return;
+    }
+
+    cv::Mat depth_org = cv_bridge::toCvCopy(msg, msg->encoding)->image;
+    cv::normalize(depth_org, depth_org, 255, 0, cv::NORM_MINMAX);
+    depth_org.convertTo(depth_img, CV_8UC1);
+    depth_img = ~depth_img;
+
+    if(real_size_scale_ == 0) return;
+
+    tf2::Matrix3x3 cam_tf_rotation(cam_tf.getRotation());
+    double roll, pitch, yaw;
+    cam_tf_rotation.getRPY(roll, pitch, yaw);
+
+    cv_bridge::CvImagePtr cv_ptr;
+    cv_ptr = cv_bridge::toCvCopy(msg, msg->encoding);
+
+    geometry_msgs::Point rect_center_msg;
+    tf2::Vector3 target_obj_uv;
+    float target_angle;
+    cv::Point2f vertices[4];
+    int rect_center_x = 0;
+    int rect_center_y = 0;
+
+    std::vector<std::vector<cv::Point>> contours;
+    cv::Mat bin_img;
+    cv::threshold(depth_img, bin_img, 0, 255, cv::THRESH_BINARY|cv::THRESH_OTSU);
+
+    //  erosion(to remove lane lines)
+    cv::Mat erode_img;
+    cv::erode(bin_img, erode_img, cv::Mat(), cv::Point(-1, -1), 3);  
+    
+    std::vector<cv::Vec4i> hierarchy;
+    cv::findContours(erode_img, contours, hierarchy, CV_RETR_EXTERNAL, CV_CHAIN_APPROX_NONE);  //  find all contours
+
+    if(contours.size() == 0) return;  //  no contours -> return
+
+    for(int i=0; i<contours.size(); i++){
+      cv::Mat input_points;
+      cv::Mat(contours[i]).convertTo(input_points, CV_32F);
+      cv::RotatedRect rects =  cv::minAreaRect(input_points);  //  detect rectangles(with degree)
+
+      cv::Point2f vertices_tmp[4];
+      rects.points(vertices_tmp);  //  get rect vertices
+
+      //  draw all rects(for debug)
+      if(debug_view_){
+	for (int i = 0; i < 4; i++){
+	  cv::line(rgb_img, vertices_tmp[i], vertices_tmp[(i+1)%4], cv::Scalar(255,0,0), 10);
+	}
+      }
+      
+      int shift_x = std::abs(rects.center.x - 0.5*image_width);
+      int shift_x_before = std::abs(rect_center_x - 0.5*image_width);
+      int change_y = std::abs(rects.center.y - rect_center_y);
+
+      //  detect rect which is most near to the center in x axis and the lowest in the y axis
+      if((shift_x < shift_x_before && change_y < std::abs(shift_x - shift_x_before)) || (rect_center_y < rects.center.y && std::abs(shift_x - shift_x_before) < change_y)){
+
+	//  exclude too low rect in y axis
+	if((image_height - vertices_tmp[0].y) < lowest_margin_) continue;
+	if((image_height - vertices_tmp[1].y) < lowest_margin_) continue;
+	if((image_height - vertices_tmp[2].y) < lowest_margin_) continue;
+	if((image_height - vertices_tmp[3].y) < lowest_margin_) continue;
+
+	rect_center_x = rects.center.x;
+	rect_center_y = rects.center.y;
+
+	target_angle = (-1) * rects.angle * M_PI / 180 + 0.78;
+	rects.points(vertices);
+      }
+    }
+    
+    //  draw target rect(for debug)
+    if(debug_view_){
+      for (int i = 0; i < 4; i++){
+	cv::line(rgb_img, vertices[i], vertices[(i+1)%4], cv::Scalar(0,255,0), 10);
+      }
+      sensor_msgs::ImagePtr rgb_msg = cv_bridge::CvImage(std_msgs::Header(), "bgr8", rgb_img).toImageMsg();
+      image_pub_.publish(rgb_msg);
+    }
+
+    //  target point(center of rect)
+    target_obj_uv.setX(rect_center_x);
+    target_obj_uv.setY(rect_center_y);
+    target_obj_uv.setZ(1.0);
+
+    object_distance = cam_tf.getOrigin().z() - object_height_;
+    
+    tf2::Vector3 object_pos_in_optical_frame = camera_K_inv_ * target_obj_uv * object_distance;
+
+    geometry_msgs::TransformStamped obj_tf_msg;
+    obj_tf_msg.header = msg->header;
+    obj_tf_msg.header.frame_id = std::string("rs_d435_color_optical_frame");
+    obj_tf_msg.child_frame_id = frame_id_;
+    obj_tf_msg.transform.translation = tf2::toMsg(object_pos_in_optical_frame);
+    obj_tf_msg.transform.rotation = tf2::toMsg(tf2::Quaternion(target_angle, pitch, roll));
+    tf_br_.sendTransform(obj_tf_msg);
+
+    target_pub_.publish(obj_tf_msg);
+  }
+}
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS (aerial_robot_perception::RectangleDetectionDepth, nodelet::Nodelet);


### PR DESCRIPTION
入力をdepthとした物体認識器を作成しました。
outputはtargetのworld座標でのxyzと機体に対する回転角度です。
画像中で最も下の部分にある物体をtargetにしています（画像中の緑枠がtarget、青枠は検出された輪郭）
またレーンの部分が線として残り認識に悪影響を与えていたので、収縮処理を行って除去しています。
![depth_rectangle_detection](https://user-images.githubusercontent.com/29499058/72328810-fba57200-36f6-11ea-95c5-33f59e41bdb6.png)
![thresh_depth](https://user-images.githubusercontent.com/29499058/72328833-03651680-36f7-11ea-9d9c-0895a9092e5e.png)
![thresh_depth_erode](https://user-images.githubusercontent.com/29499058/72328838-05c77080-36f7-11ea-9cc7-60a1887edad7.png)

よろしくお願いします。