### PR TITLE
fix rectangle detector(only focus on red objects based on its area)

### DIFF
--- a/aerial_robot_perception/include/aerial_robot_perception/rectangle_detection_depth.h
+++ b/aerial_robot_perception/include/aerial_robot_perception/rectangle_detection_depth.h
@@ -3,21 +3,20 @@
 #include <algorithm>
 #include <cstdlib>
 #include <iostream>
+#include <iomanip>
+#include <sstream>
 #include <limits>
 #include <random>
+#include <cmath>
 #include <unistd.h>
 #include <ros/ros.h>
 #include <ros/topic.h>
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/CameraInfo.h>
 #include <sensor_msgs/image_encodings.h>
-#include <std_msgs/Float64.h>
-#include <std_msgs/Int32.h>
-#include "std_msgs/MultiArrayLayout.h"
-#include "std_msgs/MultiArrayDimension.h"
-#include "std_msgs/Int32MultiArray.h"
 #include <geometry_msgs/TransformStamped.h>
-#include <geometry_msgs/Point.h>
+#include <geometry_msgs/Pose.h>
+#include <geometry_msgs/PoseArray.h>
 #include <opencv2/opencv.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <image_transport/image_transport.h>
@@ -36,7 +35,7 @@ namespace aerial_robot_perception
 
   protected:
     /* ros publisher */
-    ros::Publisher target_pub_;  
+    ros::Publisher target_pub_;
     image_transport::Publisher image_pub_;
 
     /* ros subscriber */
@@ -55,23 +54,21 @@ namespace aerial_robot_perception
     /* ros param */
     bool debug_view_;
     std::string frame_id_;
-    
+
     double real_size_scale_;
     tf2::Matrix3x3 camera_K_inv_;
     tf2::Matrix3x3 camera_K;
 
     int lowest_margin_, image_width_, image_height_;
     double object_height_, target_object_area_, target_object_area_margin_;
-    
-    double object_distance;
-    geometry_msgs::Vector3Stamped obj_pos_msg;
-    tf2::Vector3 cam_target_xyz;
-    cv::Mat rgb_img, depth_img;
+
+    cv::Mat rgb_img_;
+    std::string camera_optical_frame_name_;
 
     void imageCallback(const sensor_msgs::ImageConstPtr& msg);
     void depthImageCallback(const sensor_msgs::ImageConstPtr& msg);
     void cameraInfoCallback(const sensor_msgs::CameraInfoConstPtr& msg);
-    
+
     virtual void onInit();
     virtual void subscribe();
     virtual void unsubscribe();

--- a/aerial_robot_perception/launch/rectangle_detection_depth.launch
+++ b/aerial_robot_perception/launch/rectangle_detection_depth.launch
@@ -1,12 +1,10 @@
 <launch>
   <arg name="output_screen" default="true"/>
-  <arg name="image_topic" default="image" />
-  <arg name="image_depth_topic" default="image_depth" />
-  <arg name="camera_info_topic" default="cam_info" />
+  <arg name="rgb_image_topic" default="/rs_d435/color/image_rect_color" />
+  <arg name="depth_image_topic" default="/rs_d435/aligned_depth_to_color/image_raw" />
+  <arg name="camera_info_topic" default="/rs_d435/aligned_depth_to_color/camera_info" />
   <arg name="debug_view" default="true"/>
-  <arg name="marker_debug" default="true"/>
   <arg name="frame_id" default="target_object"/>
-  <arg name="camera" default="rs_d435"/>
   <arg name="gui" default="true"/>
 
   <node pkg="nodelet" type="nodelet" name="rectangle_detection_depth_nodelet" args="manager" output="screen" if="$(arg output_screen)"/>
@@ -14,10 +12,9 @@
   <node pkg="nodelet" type="nodelet" name="rectangle_detection_depth"
         args="load aerial_robot_perception/RectangleDetectionDepth rectangle_detection_depth_nodelet" output="screen">
 
-    <remap from="rgb_img" to="/rs_d435/color/image_rect_color" />
-    <remap from="depth_image" to="/rs_d435/aligned_depth_to_color/image_raw" />
-    <remap from="cam_info" to="/rs_d435/aligned_depth_to_color/camera_info" />
-    
+    <remap from="rgb_img" to="$(arg rgb_image_topic)" />
+    <remap from="depth_image" to="$(arg depth_image_topic)" />
+    <remap from="cam_info" to="$(arg camera_info_topic)" />
     <param name="debug_view" value="$(arg debug_view)"/>
     <param name="frame_id" value="$(arg frame_id)"/>
   </node>

--- a/aerial_robot_perception/src/rectangle_detection_depth.cpp
+++ b/aerial_robot_perception/src/rectangle_detection_depth.cpp
@@ -9,8 +9,6 @@ namespace aerial_robot_perception
 
     pnh_->param("debug_view", debug_view_, true);
     pnh_->param("frame_id", frame_id_, std::string("target"));
-    pnh_->param("image_width", image_width_, 1280);
-    pnh_->param("image_height", image_height_, 720);
     pnh_->param("lowest_margin", lowest_margin_, 10);
     pnh_->param("object_height", object_height_, 0.20);
     pnh_->param("target_object_area", target_object_area_, 0.06);
@@ -18,8 +16,8 @@ namespace aerial_robot_perception
     always_subscribe_ = true;
 
     if (debug_view_) image_pub_ = advertiseImage(*pnh_, "debug_image", 1);
-    target_pub_ = advertise<geometry_msgs::TransformStamped>(*nh_, frame_id_, 1);
-    
+    target_pub_ = advertise<geometry_msgs::PoseArray>(*pnh_, frame_id_, 1);
+
     it_ = boost::make_shared<image_transport::ImageTransport>(*nh_);
     tf_ls_ = boost::make_shared<tf2_ros::TransformListener>(tf_buff_);
 
@@ -51,7 +49,10 @@ namespace aerial_robot_perception
 
     camera_K_inv_ = camera_K_normal.inverse();
     camera_K = camera_K_normal;
+    image_height_ = msg->height;
+    image_width_ = msg->width;
     real_size_scale_ = msg->K[0] * msg->K[4];
+    camera_optical_frame_name_ = msg->header.frame_id;
     cam_info_sub_.shutdown();
   }
 
@@ -60,44 +61,33 @@ namespace aerial_robot_perception
   {
     cv_bridge::CvImagePtr cv_ptr;
     cv_ptr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::BGR8);
-    rgb_img = cv_ptr->image;
+    rgb_img_ = cv_ptr->image;
   }
 
-  
+
   void RectangleDetectionDepth::depthImageCallback(const sensor_msgs::ImageConstPtr& msg)
   {
     tf2::Transform cam_tf;
-    try{
-      geometry_msgs::TransformStamped cam_pose_msg = tf_buff_.lookupTransform("world", "rs_d435_color_optical_frame", ros::Time(0));
+    try {
+      geometry_msgs::TransformStamped cam_pose_msg = tf_buff_.lookupTransform("world", camera_optical_frame_name_, ros::Time(0), ros::Duration(0.1));
       tf2::convert(cam_pose_msg.transform, cam_tf);
-    }
-    catch (tf2::TransformException &ex) {
+    } catch (tf2::TransformException &ex) {
       ROS_WARN("%s", ex.what());
       return;
     }
 
     cv::Mat depth_org = cv_bridge::toCvCopy(msg, msg->encoding)->image;
     cv::normalize(depth_org, depth_org, 255, 0, cv::NORM_MINMAX);
+    cv::Mat depth_img;
     depth_org.convertTo(depth_img, CV_8UC1);
     depth_img = ~depth_img;
 
     if(real_size_scale_ == 0) return;
 
-    tf2::Matrix3x3 cam_tf_rotation(cam_tf.getRotation());
-    double roll, pitch, yaw;
-    cam_tf_rotation.getRPY(roll, pitch, yaw);
-
-    object_distance = cam_tf.getOrigin().z() - object_height_;
+    double object_distance = cam_tf.getOrigin().z() - object_height_;
 
     cv_bridge::CvImagePtr cv_ptr;
     cv_ptr = cv_bridge::toCvCopy(msg, msg->encoding);
-
-    geometry_msgs::Point rect_center_msg;
-    tf2::Vector3 target_obj_uv;
-    float target_angle;
-    cv::Point2f vertices[4];
-    int rect_center_x = 0;
-    int rect_center_y = 0;
 
     std::vector<std::vector<cv::Point>> contours;
     cv::Mat bin_img;
@@ -105,92 +95,139 @@ namespace aerial_robot_perception
 
     //  erosion(to remove lane lines)
     cv::Mat erode_img;
-    cv::erode(bin_img, erode_img, cv::Mat(), cv::Point(-1, -1), 3);  
-    
+    cv::erode(bin_img, erode_img, cv::Mat(), cv::Point(-1, -1), 3);
+
     std::vector<cv::Vec4i> hierarchy;
     cv::findContours(erode_img, contours, hierarchy, CV_RETR_EXTERNAL, CV_CHAIN_APPROX_NONE);  //  find all contours
 
-    if(contours.size() == 0) return;  //  no contours -> return
+    if (contours.size() == 0) {
+      NODELET_DEBUG_STREAM("no contours");
+      return;  //  no contours -> return
+    }
 
-    for(int i=0; i<contours.size(); i++){
+    std::vector<cv::RotatedRect> rects;
+    for (int i = 0; i < contours.size(); i++) {
       cv::Mat input_points;
       cv::Mat(contours[i]).convertTo(input_points, CV_32F);
-      cv::RotatedRect rects =  cv::minAreaRect(input_points);  //  detect rectangles(with degree)
+      cv::RotatedRect rect = cv::minAreaRect(input_points);  //  detect rectangles(with degree)
 
-      cv::Point2f vertices_tmp[4];
-      rects.points(vertices_tmp);  //  get rect vertices
+      cv::Point2f vertices[4];
+      rect.points(vertices);  //  get rect vertices
 
       //  check whether target object or not based on its area
       std::vector<tf2::Vector3> rect_points;
-      for(int j=0; j<3; j++){
-	tf2::Vector3 rect_point_img;
-	rect_point_img.setX(vertices_tmp[j].x);
-	rect_point_img.setY(vertices_tmp[j].y);
-	rect_point_img.setZ(1.0);
+      for (int j = 0; j < 3; j++) {
+        tf2::Vector3 rect_point_img;
+        rect_point_img.setX(vertices[j].x);
+        rect_point_img.setY(vertices[j].y);
+        rect_point_img.setZ(1.0);
 
-	tf2::Vector3 rect_point = camera_K_inv_ * rect_point_img * object_distance;
-	rect_points.push_back(rect_point);
+        tf2::Vector3 rect_point = camera_K_inv_ * rect_point_img * object_distance;
+        rect_points.push_back(rect_point);
       }
 
       double rect_area = std::sqrt(std::pow((rect_points[0].x()-rect_points[1].x()), 2.0)+std::pow((rect_points[0].y()-rect_points[1].y()), 2.0)) * std::sqrt(std::pow((rect_points[1].x()-rect_points[2].x()), 2.0)+std::pow((rect_points[1].y()-rect_points[2].y()), 2.0));
 
-      rect_points.erase(rect_points.begin(), rect_points.end());
-      if(std::abs(rect_area-target_object_area_) > target_object_area_margin_) continue;
-
-      //  draw all target rects(for debug)
-      if(debug_view_){
-	for (int j=0; j<4; j++){
-	  cv::line(rgb_img, vertices_tmp[j], vertices_tmp[(j+1)%4], cv::Scalar(255,0,0), 10);
-	}
-      }
-      
-      int shift_x = std::abs(rects.center.x - 0.5*image_width_);
-      int shift_x_before = std::abs(rect_center_x - 0.5*image_width_);
-      int change_y = std::abs(rects.center.y - rect_center_y);
-
-      //  detect rect which is most near to the center in x axis and the lowest in the y axis
-      if((shift_x < shift_x_before && change_y < std::abs(shift_x - shift_x_before)) || (rect_center_y < rects.center.y && std::abs(shift_x - shift_x_before) < change_y)){
-
-	//  exclude too low rect in y axis
-	if((image_height_ - vertices_tmp[0].y) < lowest_margin_) continue;
-	if((image_height_ - vertices_tmp[1].y) < lowest_margin_) continue;
-	if((image_height_ - vertices_tmp[2].y) < lowest_margin_) continue;
-	if((image_height_ - vertices_tmp[3].y) < lowest_margin_) continue;
-
-	rect_center_x = rects.center.x;
-	rect_center_y = rects.center.y;
-
-	target_angle = (-1) * rects.angle * M_PI / 180 + 0.78;
-	rects.points(vertices);
-      }
-    }
-    
-    //  draw target rect(for debug)
-    if(debug_view_){
-      for (int i=0; i<4; i++){
-	cv::line(rgb_img, vertices[i], vertices[(i+1)%4], cv::Scalar(0,255,0), 10);
-      }
-      cv::imwrite("/home/kuromiya/result.png", rgb_img);
-      sensor_msgs::ImagePtr rgb_msg = cv_bridge::CvImage(std_msgs::Header(), "bgr8", rgb_img).toImageMsg();
-      image_pub_.publish(rgb_msg);
+      if (std::abs(rect_area - target_object_area_) > target_object_area_margin_) continue;
+      rects.push_back(rect);
     }
 
-    //  target point(center of rect)
-    target_obj_uv.setX(rect_center_x);
-    target_obj_uv.setY(rect_center_y);
-    target_obj_uv.setZ(1.0);
-    
-    tf2::Vector3 object_pos_in_optical_frame = camera_K_inv_ * target_obj_uv * object_distance;
+    if (rects.size() == 0) {
+      NODELET_DEBUG_STREAM("no valid rects");
+      return; // no rects -> return
+    }
 
-    geometry_msgs::TransformStamped obj_tf_msg;
-    obj_tf_msg.header = msg->header;
-    obj_tf_msg.header.frame_id = std::string("rs_d435_color_optical_frame");
-    obj_tf_msg.child_frame_id = frame_id_;
-    obj_tf_msg.transform.translation = tf2::toMsg(object_pos_in_optical_frame);
-    obj_tf_msg.transform.rotation = tf2::toMsg(tf2::Quaternion(target_angle, pitch, roll));
-    tf_br_.sendTransform(obj_tf_msg);
+    //exclude too low lect in x & y axis
 
-    target_pub_.publish(obj_tf_msg);
+    std::vector<cv::RotatedRect> passed_rects;
+    for (const auto& rect : rects) {
+      cv::Point2f vertices[4];
+      rect.points(vertices);  //  get rect vertices
+
+      bool rect_ok = true;
+      for (int i = 0; i < 4; ++i) {
+        if (vertices[i].x < lowest_margin_ || (image_width_ - vertices[i].x) < lowest_margin_ || vertices[i].y < lowest_margin_ || (image_height_ - vertices[i].y) < lowest_margin_) {
+          rect_ok = false;
+        }
+      }
+      if (rect_ok) {
+        passed_rects.push_back(rect);
+      }
+    }
+
+    //publish poses of rectangles
+    int obj_count = 0;
+    geometry_msgs::PoseArray pose_array_msg;
+    pose_array_msg.header = msg->header;
+    pose_array_msg.header.frame_id = camera_optical_frame_name_;
+    std::vector<double> angles;
+
+    for (const auto& rect : passed_rects) {
+      tf2::Vector3 target_obj_uv(rect.center.x, rect.center.y, 1.0);
+      tf2::Vector3 object_pos_in_optical_frame = camera_K_inv_ * target_obj_uv * object_distance;
+
+      //calc angle : x axis directs the long side
+      cv::Point2f vertices[4];
+      rect.points(vertices);
+      double side1_len = cv::norm(vertices[0] - vertices[1]);
+      double side2_len = cv::norm(vertices[1] - vertices[2]);
+      cv::Point2f angle_vector;
+      if (side1_len >= side2_len) {
+        angle_vector = vertices[0] - vertices[1];
+      } else {
+        angle_vector = vertices[1] - vertices[2];
+      }
+      double angle = std::atan2(angle_vector.y, angle_vector.x);
+      if (0.0 <= angle && angle < M_PI) {
+        angle += M_PI;
+      }
+
+      angles.push_back(angle);
+
+      std::ios::fmtflags curret_flag = std::cout.flags();
+      std::ostringstream ss;
+      ss << std::setw(2) << std::setfill('0') << obj_count;
+      std::cout.flags(curret_flag);
+
+      geometry_msgs::TransformStamped obj_tf_msg;
+      obj_tf_msg.header = msg->header;
+      obj_tf_msg.header.frame_id = camera_optical_frame_name_;
+      obj_tf_msg.child_frame_id = frame_id_ + ss.str();
+      obj_tf_msg.transform.translation = tf2::toMsg(object_pos_in_optical_frame);
+      tf2::Quaternion q;
+      q.setRPY(0, 0, angle);
+      obj_tf_msg.transform.rotation = tf2::toMsg(q);
+      tf_br_.sendTransform(obj_tf_msg);
+
+      geometry_msgs::Pose pose;
+      pose.position.x = obj_tf_msg.transform.translation.x;
+      pose.position.y = obj_tf_msg.transform.translation.y;
+      pose.position.z = obj_tf_msg.transform.translation.z;
+      pose.orientation = obj_tf_msg.transform.rotation;
+      pose_array_msg.poses.push_back(pose);
+      obj_count++;
+    }
+
+    target_pub_.publish(pose_array_msg);
+
+    //  draw all target rects(for debug)
+    if (debug_view_) {
+      cv::Mat debug_img;
+      rgb_img_.copyTo(debug_img);
+      for (int i = 0; i < passed_rects.size(); ++i) {
+        cv::Point2f vertices[4];
+        passed_rects[i].points(vertices);
+        for (int i = 0; i < 4; ++i) {
+          cv::line(debug_img, vertices[i], vertices[(i+1)%4], cv::Scalar(255,0,0), 10); //blue
+        }
+        cv::Point2f arrow_point = cv::Point2f(50.0 * std::cos(angles[i]), 50.0 * std::sin(angles[i])) + passed_rects[i].center;
+        cv::arrowedLine(debug_img, passed_rects[i].center, arrow_point, cv::Scalar(0, 0, 0), 3, CV_AA, 0, 0.4);
+      }
+      sensor_msgs::ImagePtr debug_img_msg = cv_bridge::CvImage(std_msgs::Header(), "bgr8", debug_img).toImageMsg();
+      image_pub_.publish(debug_img_msg);
+    }
+
+
   }
 }
 


### PR DESCRIPTION
把持対象となる物体の面積に基づいて、それ以外の物体を候補から外す機能を追加しました。
下の画像では緑の物体の輪郭も検出されていますが、面積が異なるため排除しています。
![result](https://user-images.githubusercontent.com/29499058/72434926-2b7c7480-37e0-11ea-8697-56a3451b9e25.png)
