### PR TITLE
add all_contour flag in ground object detection

### DIFF
--- a/aerial_robot_perception/include/aerial_robot_perception/ground_object_detection.h
+++ b/aerial_robot_perception/include/aerial_robot_perception/ground_object_detection.h
@@ -82,6 +82,7 @@ namespace aerial_robot_perception
     double contour_area_size_, contour_area_margin_;
     double object_height_;
     double contour_area_min_thre;
+    bool all_contour_;
 
     bool debug_view_;
     std::string frame_id_;


### PR DESCRIPTION
Ground Object Detectionに、contourの探すのではなくすべてのマスク（白の画素）の重心を出力するフラグを追加しました．
task2の置く部分の認識器はこのモードを使ったほうがパフォーマンスが上がりました．

@makit0sh task3で使っていると思うのでレビューお願いします．
一応task2のシミュレーションではflagがfalseの場合でも問題なく動いていました．