### PR TITLE
Devel/noetic/build

### DIFF
--- a/aerial_robot_perception/CMakeLists.txt
+++ b/aerial_robot_perception/CMakeLists.txt
@@ -43,7 +43,7 @@ include_directories(
   )
 
 # download and install sample data
-add_custom_target(install_sample_data ALL COMMAND ${PROJECT_SOURCE_DIR}/scripts/install_test_data.py)
+# add_custom_target(install_sample_data ALL COMMAND ${PROJECT_SOURCE_DIR}/scripts/install_test_data.py)
 
 
 macro(arp_add_nodelet _nodelet_cpp _nodelet_class _single_nodelet_exec_name)

--- a/aerial_robot_perception/src/rectangle_detection.cpp
+++ b/aerial_robot_perception/src/rectangle_detection.cpp
@@ -224,12 +224,12 @@ namespace aerial_robot_perception
             cv::line(debug_img, vertices[i], vertices[(i+1)%4], cv::Scalar(255,0,0), 10); //blue
           }
           cv::Point2f arrow_point = cv::Point2f(50.0 * std::cos(angles[i]), 50.0 * std::sin(angles[i])) + passed_rects[i].center;
-          cv::arrowedLine(debug_img, passed_rects[i].center, arrow_point, cv::Scalar(0, 0, 0), 3, CV_AA, 0, 0.4);
+          cv::arrowedLine(debug_img, passed_rects[i].center, arrow_point, cv::Scalar(0, 0, 0), 3, cv::LINE_AA, 0, 0.4);
         }
       } else {
         //no rects
         //cv::putText(debug_img, "no rect", cv::Point(0, 0), cv::FONT_HERSHEY_PLAIN, 100, cv::Scalar(0, 0, 0), 3);
-        cv::putText(debug_img, fail_msg_.c_str(), cv::Point(10, 50), cv::FONT_HERSHEY_SIMPLEX, 1.2, cv::Scalar(0,0,200), 2, CV_AA);
+        cv::putText(debug_img, fail_msg_.c_str(), cv::Point(10, 50), cv::FONT_HERSHEY_SIMPLEX, 1.2, cv::Scalar(0,0,200), 2, cv::LINE_AA);
       }
       sensor_msgs::ImagePtr debug_img_msg = cv_bridge::CvImage(msg->header, rgb_img_encoding_, debug_img).toImageMsg();
       debug_image_pub_.publish(debug_img_msg);


### PR DESCRIPTION
### What is this

Successful build in ROS noetic 

### Details

- delete test_data in building for this file is server inside of JSK now.
- replace CV_AA to cv::LINE_AA to fit OPENCV version (4.2.0)

### TODO
- [ ] evaluate this recognition with jsk_aerial_robot repository